### PR TITLE
add jniLibs.srcDirs property to build.gradle

### DIFF
--- a/android/ijkmediaplayer-arm64-v8a/build.gradle
+++ b/android/ijkmediaplayer-arm64-v8a/build.gradle
@@ -8,11 +8,7 @@ android {
         main {
             manifest.srcFile 'AndroidManifest.xml'
             java.srcDirs = ['src']
-            resources.srcDirs = ['src']
-            aidl.srcDirs = ['src']
-            renderscript.srcDirs = ['src']
-            res.srcDirs = ['res']
-            assets.srcDirs = ['assets']
+            jniLibs.srcDirs = ['libs']
         }
 
         // Move the tests to tests/java, tests/res, etc...


### PR DESCRIPTION
Without this line the final APK will not contain all the lib/*.so files, and will crash on System.loadLibrary(..)
The removed lines seem to be unnecessary (see other build.gradle files)